### PR TITLE
Fix to work on Sanic 0.7

### DIFF
--- a/sanic_sentry.py
+++ b/sanic_sentry.py
@@ -1,6 +1,7 @@
 import logging
 
 import sanic
+from sanic.log import logger
 
 import raven
 import raven_aiohttp
@@ -21,7 +22,6 @@ class SanicSentry:
             transport=raven_aiohttp.AioHttpTransport,
         )
         self.handler = SentryHandler(client=self.client, level=app.config.get('SENTRY_LEVEL', logging.ERROR))
-        logger = logging.getLogger('sanic')
         logger.addHandler(self.handler)
         self.app = app
         self.app.sentry = self


### PR DESCRIPTION
Sanic 0.7 changed the logger name and is now using the 'root' logger (instead of 'sanic').
I think it is better to import it directly from Sanic than to use `logging.getLogger` to avoid this kind of problem in the future...