### PR TITLE
Add SENTRY_PARAMS for passing advanced args to the raven client

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,10 +42,14 @@ Or use `init_app` to reverse dependency:
 
 *Optional parameters:* 
 
-**SENTRY_RELEASE**  - Configure a custom release for sentry
-Explained in https://docs.sentry.io/learn/releases/
+**SENTRY_PARAMS**  - Configure advanced parameters for sentry:
+Explained in https://docs.sentry.io/clients/python/advanced/
 
 .. code:: python
->>> app.config['SENTRY_RELEASE'] = 'myapp_v0.4'
+>>> app.config['SENTRY_PARAMS'] = {
+    "release": "0.3",
+    "environment": "production"
+    ...
+}
 
 

--- a/sanic_sentry.py
+++ b/sanic_sentry.py
@@ -24,7 +24,7 @@ class SanicSentry:
         self.client = raven.Client(
             dsn=app.config['SENTRY_DSN'],
             transport=raven_aiohttp.AioHttpTransport,
-            **app.config.get('SENTRY_PARAMS')
+            **app.config.get('SENTRY_PARAMS', {})
         )
         self.handler = SentryHandler(client=self.client, level=app.config.get('SENTRY_LEVEL', logging.ERROR))
         logger.addHandler(self.handler)

--- a/sanic_sentry.py
+++ b/sanic_sentry.py
@@ -24,7 +24,7 @@ class SanicSentry:
         self.client = raven.Client(
             dsn=app.config['SENTRY_DSN'],
             transport=raven_aiohttp.AioHttpTransport,
-            release=app.config.get('SENTRY_RELEASE', None)
+            **app.config.get('SENTRY_PARAMS')
         )
         self.handler = SentryHandler(client=self.client, level=app.config.get('SENTRY_LEVEL', logging.ERROR))
         logger.addHandler(self.handler)


### PR DESCRIPTION
resolves: https://github.com/serathius/sanic-sentry/issues/14