### PR TITLE
Fix requirements.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
-include README.md
+include README.rst
+include requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,7 @@ from setuptools import setup
 
 
 def _read(fname):
-    try:
-        return open(op.join(op.dirname(__file__), fname)).read()
-    except IOError:
-        return ''
+    return open(op.join(op.dirname(__file__), fname)).read()
 
 
 install_requires = [


### PR DESCRIPTION
Hey. Your package didn't have `Requires Distributions` listed on pypi: https://pypi.python.org/pypi/sanic-sentry/0.1.3 . There was even error silencing in setup.py. Here is the fix for that.

Please release it because without it pip-compile does not include dependencies.