### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sanic
 raven
 raven-aiohttp
-aiohttp<3.0.0
+aiohttp


### PR DESCRIPTION
raven_aiohttp supports aiohttp > 2. With this limitation in requirement file, sanic-sentry is not  compatible with the last aiohttp