### PR TITLE
Match sanic release in tests scenarios

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: python
+sudo: required
+dist: xenial
 
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
 
 install: pip install tox-travis
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sanic
+sanic>=18.12
 raven
 raven-aiohttp
 aiohttp

--- a/sanic_sentry.py
+++ b/sanic_sentry.py
@@ -1,15 +1,11 @@
 import logging
 
 import sanic
+from sanic.log import logger
 
 import raven
 import raven_aiohttp
 from raven.handlers.logging import SentryHandler
-
-try:
-    from sanic.log import logger
-except ImportError:
-    logger = logging.getLogger('sanic')
 
 
 class SanicSentry:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-    {py35,py36}-{sanic06,sanic07}
+    {py35,py36}-sanicLTS
+    {py36}-{sanicLTS,sanic}
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_*
@@ -17,5 +18,4 @@ deps =
     -e{toxinidir}
     -r{toxinidir}/requirements_tests.txt
     codecov
-    sanic06: sanic<0.7
-    sanic06: websockets<4.0
+    sanicLTS: sanic==18.12

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    {py35,py36}-sanicLTS
-    {py36}-{sanicLTS,sanic}
+    {py35,py36,py37}-sanicLTS
+    {py36,py37}-{sanicLTS,sanic}
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_*
@@ -12,6 +12,7 @@ commands =
     python setup.py checkdocs
     codecov
 basepython =
+    py37: python3.7
     py36: python3.6
     py35: python3.5
 deps =


### PR DESCRIPTION
Drop 0.6 sanic support
Test sanic LTS version 18.12
Remove testing python3.5 on upsteam as it's no longer supported since
19.6.0